### PR TITLE
add option for plain http registries

### DIFF
--- a/containerd/containerd.go
+++ b/containerd/containerd.go
@@ -86,10 +86,12 @@ func (d *Driver) parshAuth(auth *RegistryAuth) CredentialsOpt {
 	}
 }
 
-func withResolver(creds CredentialsOpt) containerd.RemoteOpt {
+func withResolver(creds CredentialsOpt, usePlainHttp bool) containerd.RemoteOpt {
 	resolver := remotesdocker.NewResolver(remotesdocker.ResolverOptions{
-		Hosts: remotesdocker.ConfigureDefaultRegistries(remotesdocker.WithAuthorizer(
-			remotesdocker.NewDockerAuthorizer(remotesdocker.WithAuthCreds(creds)))),
+		Hosts: remotesdocker.ConfigureDefaultRegistries(
+			remotesdocker.WithAuthorizer(remotesdocker.NewDockerAuthorizer(remotesdocker.WithAuthCreds(creds))),
+			remotesdocker.WithPlainHTTP(func(f string) (bool, error) { return usePlainHttp, nil }),
+		),
 	})
 	return containerd.WithResolver(resolver)
 }
@@ -115,7 +117,7 @@ func withFileLimit(maxOpenFiles uint64) oci.SpecOpts {
 	}
 }
 
-func (d *Driver) pullImage(imageName, imagePullTimeout string, auth *RegistryAuth) (containerd.Image, error) {
+func (d *Driver) pullImage(imageName, imagePullTimeout string, auth *RegistryAuth, usePlainHttp bool) (containerd.Image, error) {
 	pullTimeout, err := time.ParseDuration(imagePullTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse image_pull_timeout: %v", err)
@@ -131,7 +133,7 @@ func (d *Driver) pullImage(imageName, imagePullTimeout string, auth *RegistryAut
 
 	pullOpts := []containerd.RemoteOpt{
 		containerd.WithPullUnpack,
-		withResolver(d.parshAuth(auth)),
+		withResolver(d.parshAuth(auth), usePlainHttp),
 	}
 
 	return d.client.Pull(ctxWithTimeout, named.String(), pullOpts...)

--- a/containerd/driver.go
+++ b/containerd/driver.go
@@ -130,6 +130,10 @@ var (
 			"username": hclspec.NewAttr("username", "string", true),
 			"password": hclspec.NewAttr("password", "string", true),
 		})),
+		"use_plain_http": hclspec.NewDefault(
+			hclspec.NewAttr("use_plain_http", "bool", false),
+			hclspec.NewLiteral("false"),
+		),
 		"mounts": hclspec.NewBlockList("mounts", hclspec.NewObject(map[string]*hclspec.Spec{
 			"type": hclspec.NewDefault(
 				hclspec.NewAttr("type", "string", false),
@@ -204,6 +208,7 @@ type TaskConfig struct {
 	ReadOnlyRootfs   bool               `codec:"readonly_rootfs"`
 	HostNetwork      bool               `codec:"host_network"`
 	Auth             RegistryAuth       `codec:"auth"`
+	UsePlainHttp     bool               `codec:"use_plain_http"`
 	Mounts           []Mount            `codec:"mounts"`
 }
 
@@ -440,7 +445,7 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 	containerConfig.ContainerName = containerName
 
 	var err error
-	containerConfig.Image, err = d.pullImage(driverConfig.Image, driverConfig.ImagePullTimeout, &driverConfig.Auth)
+	containerConfig.Image, err = d.pullImage(driverConfig.Image, driverConfig.ImagePullTimeout, &driverConfig.Auth, driverConfig.UsePlainHttp)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error in pulling image %s: %v", driverConfig.Image, err)
 	}


### PR DESCRIPTION
I wanted to use my private registry without the hassle of setting up certificates, so I had to find a way to make HTTP work. Since I couldn't find a `skip verify` or `insecure registry` option like in containerd or nerdctl, I ended up digging into the source code. Go is still on my todo list, but the solution does the job. The `use_plain_http` option, found under task configuration, now allows registries to use plain HTTP.

```
task "name" {
   ...
   config {
     image = "private:latest"
     use_plain_http = true
     ...
   }
}
```